### PR TITLE
Fix incorrect content type returned in `metadata.get_xml`

### DIFF
--- a/koordinates/metadata.py
+++ b/koordinates/metadata.py
@@ -60,7 +60,9 @@ class Metadata(base.InnerModel):
         If you pass this function an open file-like object as the fp parameter, the function will
         not close that file for you.
         """
-        r = self._client.request("GET", getattr(self, format), stream=True)
+        r = self._client.request(
+            "GET", getattr(self, format), headers={"Accept": "text/xml"}, stream=True
+        )
         filename = stream.stream_response_to_file(r, path=fp)
         return filename
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements-test.txt
 
 Babel~=2.7
-Jinja2~=2.11
+Jinja2<3.1
 MarkupSafe
 Pygments
 Sphinx~=3.0


### PR DESCRIPTION
Datastet metadata endpoints were updated to return the correct content-type given supplied `Accept` headers. Previously, `text/xml` was always returned unless a `format` parameter was provided. This had the side effect of altering the default behavior of `.metadata.get_xml` to return JSON instead of XML data.

This fixes the issue by supplying the header `Accept: text/xml` to request the correct content type response.