### PR TITLE
Detect redirects and fail fast

### DIFF
--- a/koordinates/client.py
+++ b/koordinates/client.py
@@ -294,7 +294,7 @@ class Client(object):
         "SET": {
             "GET": {
                 "single": "/sets/{id}/",
-                "metadata": "/sets/{id}/metadata",
+                "metadata": "/sets/{id}/metadata/",
                 "multi": "/sets/",
                 "multidraft": "/sets/drafts/",
             },

--- a/koordinates/client.py
+++ b/koordinates/client.py
@@ -194,7 +194,7 @@ class Client(object):
             r = e.response
             location = r.headers.get("Location")
             raise exceptions.RedirectException(
-                f"Server responded with redirect ({r.status_code} {location}) - check you have the client host correctly configured"
+                f"Server responded with redirect ({r.status_code} {location})"
             ) from None
         except requests.RequestException as e:
             raise exceptions.ServerError.from_requests_error(e)

--- a/koordinates/client.py
+++ b/koordinates/client.py
@@ -87,6 +87,7 @@ class Client(object):
         )
 
         self._session = requests.Session()
+        self._session.max_redirects = 0
         self._session.headers.update(
             {"Accept": "application/json", "User-Agent": self._user_agent,}
         )
@@ -189,6 +190,12 @@ class Client(object):
         except requests.HTTPError as e:
             logger.warning("Response: %s: %s", e, r.text)
             raise exceptions.ServerError.from_requests_error(e)
+        except requests.exceptions.TooManyRedirects as e:
+            r = e.response
+            location = r.headers.get("Location")
+            raise exceptions.RedirectException(
+                f"Server responded with redirect ({r.status_code} {location}) - check you have the client host correctly configured"
+            ) from None
         except requests.RequestException as e:
             raise exceptions.ServerError.from_requests_error(e)
 
@@ -241,7 +248,7 @@ class Client(object):
         :param datatype: a string identifying the data the url will access.
         :param verb: the HTTP verb needed for use with the url.
         :param urltype: an adjective used to the nature of the request.
-        :param \*\*params: substitution variables for the URL.
+        :param params: substitution variables for the URL.
         :return: string
         :rtype: A fully formed url.
         """

--- a/koordinates/exceptions.py
+++ b/koordinates/exceptions.py
@@ -26,6 +26,12 @@ class InvalidAPIVersion(ClientError):
     pass
 
 
+class RedirectException(KoordinatesException):
+    """ Received a redirect: this isn't an API endpoint """
+
+    pass
+
+
 # Server Errors
 class ServerError(KoordinatesException):
     """ Base class for errors returned from the API Servers """

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -24,5 +24,5 @@ def test_redirect_handling():
             layer = www_client.layers.get(ID)
 
         assert e.value.args == (
-            "Server responded with redirect (302 https://test.koordinates.com/services/api/v1/layers/1474/) - check you have the client host correctly configured",
+            "Server responded with redirect (302 https://test.koordinates.com/services/api/v1/layers/1474/)",
         )

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,0 +1,28 @@
+import pytest
+import responses
+from koordinates import Client
+from koordinates.exceptions import RedirectException
+
+
+def test_redirect_handling():
+    www_client = Client(token="test", host="www.test.koordinates.com")
+    test_client = Client(token="test", host="test.koordinates.com")
+    ID = 1474
+
+    www_url = www_client.get_url("LAYER", "GET", "single", {"id": ID})
+    test_url = test_client.get_url("LAYER", "GET", "single", {"id": ID})
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            www_url,
+            status=302,
+            adding_headers={"Location": test_url},
+        )
+
+        with pytest.raises(RedirectException) as e:
+            layer = www_client.layers.get(ID)
+
+        assert e.value.args == (
+            "Server responded with redirect (302 https://test.koordinates.com/services/api/v1/layers/1474/) - check you have the client host correctly configured",
+        )


### PR DESCRIPTION
Following redirects seems like it might be useful but -

- for a correctly configured client, there's no redirects to follow
- auth is stripped when following redirects for security reasons
- following redirects with no auth leads to confusion: see #51 and #52