### PR TITLE
Fix up redirect fail-fast behaviour

### DIFF
--- a/koordinates/exceptions.py
+++ b/koordinates/exceptions.py
@@ -27,7 +27,7 @@ class InvalidAPIVersion(ClientError):
 
 
 class RedirectException(KoordinatesException):
-    """ Received a redirect: this isn't an API endpoint """
+    """ Received a redirect that we didn't expect """
 
     pass
 

--- a/koordinates/exports.py
+++ b/koordinates/exports.py
@@ -334,7 +334,7 @@ class Export(base.Model):
                 # only close a file we open
                 stack.callback(fd.close)
 
-            r = self._manager.client.request("GET", self.download_url, stream=True)
+            r = self._manager.client.request("GET", self.download_url, stream=True, allow_xdomain_redirects=True)
             stack.callback(r.close)
 
             bytes_written = 0

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -3,6 +3,8 @@ import responses
 from koordinates import Client
 from koordinates.exceptions import RedirectException
 
+from .response_data.responses_2 import layers_single_good_simulated_response
+
 
 def test_redirect_handling():
     www_client = Client(token="test", host="www.test.koordinates.com")
@@ -19,10 +21,17 @@ def test_redirect_handling():
             status=302,
             adding_headers={"Location": test_url},
         )
+        rsps.add(
+            responses.GET,
+            test_url,
+            status=200,
+            body=layers_single_good_simulated_response,
+            content_type="application/json",
+        )
 
         with pytest.raises(RedirectException) as e:
             layer = www_client.layers.get(ID)
 
         assert e.value.args == (
-            "Server responded with redirect (302 https://test.koordinates.com/services/api/v1/layers/1474/)",
+            "Server responded with cross-domain redirect (https://www.test.koordinates.com/services/api/v1/layers/1474/ -> https://test.koordinates.com/services/api/v1/layers/1474/)",
         )


### PR DESCRIPTION
Previous commit was too strict - some redirects are good
- same domain redirects are useful if a layer has moved somehow
- download URL xdomain-redirects to hosted storage, special-cased