### PR TITLE
Enhancement: Allow Users to Specify API Version of URL Endpoint to Query

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
       - id: check-added-large-files
       - id: check-json
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: '24.8.0'
     hooks:
       - id: black

--- a/koordinates/client.py
+++ b/koordinates/client.py
@@ -36,7 +36,7 @@ class Client(object):
     is instantiated.
     """
 
-    def __init__(self, host, token=None, activate_logging=False):
+    def __init__(self, host, token=None, activate_logging=False, api_version="v1"):
         """
         :param str host: the domain name of the Koordinates site to connect to (eg. ``labs.koordinates.com``)
         :param str token: Koordinates API token to use for authentication
@@ -52,6 +52,7 @@ class Client(object):
         logger.debug("Initializing Client object for %s", host)
 
         self.host = host
+        self.api_version = api_version
 
         if token:
             self.token = token
@@ -63,7 +64,7 @@ class Client(object):
             )
 
         self._user_agent = requests_toolbelt.user_agent(
-            "KoordinatesPython", _version('koordinates')
+            "KoordinatesPython", _version("koordinates")
         )
 
         self._init_managers(
@@ -89,7 +90,10 @@ class Client(object):
 
         self._session = requests.Session()
         self._session.headers.update(
-            {"Accept": "application/json", "User-Agent": self._user_agent,}
+            {
+                "Accept": "application/json",
+                "User-Agent": self._user_agent,
+            }
         )
         if self.token:
             self._session.headers["Authorization"] = "key {token}".format(
@@ -166,7 +170,9 @@ class Client(object):
 
         return r
 
-    def _raw_request(self, method, url, headers, *args, allow_xdomain_redirects=False, **kwargs):
+    def _raw_request(
+        self, method, url, headers, *args, allow_xdomain_redirects=False, **kwargs
+    ):
         # for the Koordinates library logging, strip auth tokens from log messages
         # and log POST/PUT bodies if we're sending JSON.
         # Get low-level logging via the requests.packages.urllib3 logger.
@@ -201,7 +207,7 @@ class Client(object):
         return urlparse(url1).hostname == urlparse(url2).hostname
 
     def get_url_path(self, datatype, verb, urltype, params={}, api_version=None):
-        api_version = api_version or "v1"
+        api_version = api_version or self.api_version
         templates = getattr(self, "URL_TEMPLATES__%s" % api_version)
 
         url = templates[datatype][verb][urltype]
@@ -219,7 +225,7 @@ class Client(object):
         :param urltype: an adjective used to the nature of the request.
         :return: dict
         """
-        api_version = api_version or "v1"
+        api_version = api_version or self.api_version
         templates = getattr(self, "URL_TEMPLATES__%s" % api_version)
 
         # this is fairly simplistic, if necessary we could use the parse lib
@@ -253,7 +259,7 @@ class Client(object):
         :return: string
         :rtype: A fully formed url.
         """
-        api_version = api_version or "v1"
+        api_version = api_version or self.api_version
         api_host = api_host or self.host
 
         subst = params.copy()
@@ -275,7 +281,9 @@ class Client(object):
                 "create": "/layers/",
                 "update": "/layers/{layer_id}/versions/import/",
             },
-            "DELETE": {"delete": "/layers/{id}/",},
+            "DELETE": {
+                "delete": "/layers/{id}/",
+            },
         },
         "LAYER_VERSION": {
             "GET": {
@@ -289,8 +297,12 @@ class Client(object):
                 "import": "/layers/{layer_id}/versions/{version_id}/import/",
                 "publish": "/layers/{layer_id}/versions/{version_id}/publish/",
             },
-            "PUT": {"edit": "/layers/{layer_id}/versions/{version_id}/",},
-            "DELETE": {"single": "/layers/{layer_id}/versions/{version_id}/",},
+            "PUT": {
+                "edit": "/layers/{layer_id}/versions/{version_id}/",
+            },
+            "DELETE": {
+                "single": "/layers/{layer_id}/versions/{version_id}/",
+            },
         },
         "SET": {
             "GET": {
@@ -299,8 +311,12 @@ class Client(object):
                 "multi": "/sets/",
                 "multidraft": "/sets/drafts/",
             },
-            "POST": {"create": "/sets/",},
-            "DELETE": {"delete": "/sets/{id}/",},
+            "POST": {
+                "create": "/sets/",
+            },
+            "DELETE": {
+                "delete": "/sets/{id}/",
+            },
         },
         "SET_VERSION": {
             "GET": {
@@ -313,14 +329,30 @@ class Client(object):
                 "create": "/sets/{id}/versions/",
                 "publish": "/sets/{id}/versions/{version_id}/publish/",
             },
-            "PUT": {"edit": "/sets/{id}/versions/{version_id}/",},
-            "DELETE": {"single": "/sets/{id}/versions/{version_id}/",},
+            "PUT": {
+                "edit": "/sets/{id}/versions/{version_id}/",
+            },
+            "DELETE": {
+                "single": "/sets/{id}/versions/{version_id}/",
+            },
         },
-        "CATALOG": {"GET": {"multi": "/data/", "latest": "/data/latest/",},},
+        "CATALOG": {
+            "GET": {
+                "multi": "/data/",
+                "latest": "/data/latest/",
+            },
+        },
         "PUBLISH": {
-            "GET": {"single": "/publish/{id}/", "multi": "/publish/",},
-            "POST": {"create": "/publish/",},
-            "DELETE": {"single": "/publish/{id}/",},
+            "GET": {
+                "single": "/publish/{id}/",
+                "multi": "/publish/",
+            },
+            "POST": {
+                "create": "/publish/",
+            },
+            "DELETE": {
+                "single": "/publish/{id}/",
+            },
         },
         "LICENSE": {
             "GET": {
@@ -331,13 +363,24 @@ class Client(object):
         },
         "METADATA": {
             # InnerManager, so relative to a parent object
-            "GET": {"get": "metadata/",},
-            "POST": {"set": "metadata/",},
+            "GET": {
+                "get": "metadata/",
+            },
+            "POST": {
+                "set": "metadata/",
+            },
         },
         "SOURCE": {
-            "GET": {"single": "/sources/{id}/", "multi": "/sources/",},
-            "POST": {"create": "/sources/",},
-            "DELETE": {"single": "/sources/{id}/",},
+            "GET": {
+                "single": "/sources/{id}/",
+                "multi": "/sources/",
+            },
+            "POST": {
+                "create": "/sources/",
+            },
+            "DELETE": {
+                "single": "/sources/{id}/",
+            },
         },
         "SCAN": {
             "GET": {
@@ -346,8 +389,12 @@ class Client(object):
                 "log": "/sources/{source_id}/scans/{scan_id}/log/",
                 "all": "/sources/scans/",
             },
-            "DELETE": {"cancel": "/sources/{source_id}/scans/{scan_id}/",},
-            "POST": {"create": "/sources/{source_id}/scans/",},
+            "DELETE": {
+                "cancel": "/sources/{source_id}/scans/{scan_id}/",
+            },
+            "POST": {
+                "create": "/sources/{source_id}/scans/",
+            },
         },
         "DATASOURCE": {
             "GET": {
@@ -357,15 +404,32 @@ class Client(object):
         },
         # InnerManager, so relative to a parent object
         "PERMISSION": {
-            "GET": {"multi": "permissions/", "single": "permissions/{permission_id}/",},
-            "POST": {"single": "permissions/",},
-            "PUT": {"multi": "permissions/",},
+            "GET": {
+                "multi": "permissions/",
+                "single": "permissions/{permission_id}/",
+            },
+            "POST": {
+                "single": "permissions/",
+            },
+            "PUT": {
+                "multi": "permissions/",
+            },
         },
         "EXPORT": {
-            "GET": {"multi": "/exports/", "single": "/exports/{id}/",},
-            "POST": {"create": "/exports/", "validate": "/exports/validate/",},
-            "OPTIONS": {"options": "/exports/",},
-            "DELETE": {"single": "/exports/{id}/",},
+            "GET": {
+                "multi": "/exports/",
+                "single": "/exports/{id}/",
+            },
+            "POST": {
+                "create": "/exports/",
+                "validate": "/exports/validate/",
+            },
+            "OPTIONS": {
+                "options": "/exports/",
+            },
+            "DELETE": {
+                "single": "/exports/{id}/",
+            },
         },
         "CROPLAYER": {
             "GET": {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -100,9 +100,14 @@ def client():
     client._register_manager(FooModel, client.mgr)
     client._register_manager(BarModel, BarManager(client))
 
-    client.URL_TEMPLATES__v1.update(
+    client._URL_TEMPLATES["v1"].update(
         {
-            "TEST_FOO": {"GET": {"multi": "foo/", "single": "foo/{id}/",}},
+            "TEST_FOO": {
+                "GET": {
+                    "multi": "foo/",
+                    "single": "foo/{id}/",
+                }
+            },
             "TEST_BAR": {
                 "GET": {
                     "multi": "foo/{foo_id}/bar/",
@@ -160,7 +165,11 @@ class TestModels(object):
 
     def test_deserialize_list(self, client):
         o = FooModel()._deserialize(
-            {"mylist": [1, 2], "created_at": ["2013-01-01", "2014-01-01"],}, client.mgr
+            {
+                "mylist": [1, 2],
+                "created_at": ["2013-01-01", "2014-01-01"],
+            },
+            client.mgr,
         )
         assert isinstance(o.mylist, list)
         assert o.mylist == [1, 2]
@@ -231,7 +240,10 @@ class TestModels(object):
             "id": 12345,
             "url": FooManager.TEST_GET_URL % 12345,
             "name": "foo",
-            "pop": {"id": 3456, "type": "double-happy",},
+            "pop": {
+                "id": 3456,
+                "type": "double-happy",
+            },
         }
         o_foo = FooModel()._deserialize(FOO_DATA, client.mgr)
 
@@ -265,7 +277,10 @@ class TestModels(object):
             "id": 12345,
             "url": FooManager.TEST_GET_URL % 12345,
             "name": "foo",
-            "pop": {"id": 3456, "type": "double-happy",},
+            "pop": {
+                "id": 3456,
+                "type": "double-happy",
+            },
         }
         o_foo = FooModel()._deserialize(FOO_DATA, client.mgr)
         o_pop = o_foo.pop
@@ -359,7 +374,10 @@ class TestModels(object):
             "id": 12345,
             "url": FooManager.TEST_GET_URL % 12345,
             "name": "foo",
-            "pop": {"id": 3456, "type": "double-happy",},
+            "pop": {
+                "id": 3456,
+                "type": "double-happy",
+            },
         }
         o_foo = FooModel()._deserialize(FOO_DATA, client.mgr)
         o_pop = o_foo.pop


### PR DESCRIPTION
Fixes #55.

# Description

Major changes:
- Added `url_version` attribute to `koordinates.Client`; this allows the user to explicitly specify the API version of the URL endpoint they'd like to query.
- Added `api_version` attribute to  `koordinates.Client`, which specifies the version of the Koordinates API that should be assumed to work out request/response structures. This can differ from the `url_version` (e.g. `api_version='v1'` vs `url_version=v1.x`).
- Removed `URL_TEMPLATES__v1` in favour of a `_get_url_templates` helper method. This prints more understandable error messages in cases where the user requests an invalid `api_version`. This change should also make it easier to accommodate new `koordinates` API versions in the future.
- Added new tests for `url_version` attribute.
- Modified test fixtures that explicitly referenced `URL_TEMPLATES__v1`.

Miscellaneous changes:
- Bumped `black` version in `.pre-commit-config.yaml` to 24.8.0 to avoid issues with `click`; see https://github.com/psf/black/issues/2964.
- Removed rogue `print` statement in tests.

Example:
```python
import koordinates

host = "data.linz.govt.nz"
linz_api_key = '123'
client = koordinates.Client(host="data.linz.govt.nz", token='123', url_version='v1.x')
print(client.get_url("PUBLISH", "DELETE", "single", {"id": 'abc'}))
```
This prints: `https://data.linz.govt.nz/services/api/v1.x/publish/abc/`.

Any feedback/suggestions are welcome.

Cheers,
Matt.
